### PR TITLE
Add support for proxy connections and command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 # PV_Forecast-API
 A Python implementation of the PV_Forecast web API. See [www.solar.sheffield.ac.uk/pvforecast/](https://www.solar.sheffield.ac.uk/pvforecast/) and [api.solar.sheffield.ac.uk](https://api.solar.sheffield.ac.uk/)
 
-**Latest Version: 0.4**
+**Latest Version: 0.5*
 
 **New! Updated 2022-08-01 to use PV_Forecast API v4.**
+**New! Updated 2022-12-12 to add support for proxy connections and add command line arguments.**
 
 ## About this repository
 
@@ -58,6 +59,44 @@ pvf = PVForecast(user_id="", api_key="") # Enter your user_id and api_key here!
 |Get the latest aggregated outturn forecast for **GSP** ID **152** (INDQ1 or "Indian Queens")|`pvf.latest(entity_type="gsp", entity_id=152, dataframe=True)`|![Screenshot of output](/misc/code_example_output2.png?raw=true)
 |Get the nationally aggregated GB PV outturn forecast with forecast base `2021-02-23T07:00:00Z` as a DataFrame|`pvf.get_forecast(datetime(2021, 2, 23, 7, 0, tzinfo=pytz.utc), dataframe=True))`|![Screenshot of output](/misc/code_example_output3.png?raw=true)|
 |Get all 07:00 nationally aggregated GB PV outturn forecasts between `2021-02-23T01:00:00Z` and `2021-02-23T07:00:00Z`, as a DataFrame|`pvf.get_forecasts(datetime(2021, 2, 23, 1, 0, tzinfo=pytz.utc), datetime(2021, 2, 23, 7, 0, tzinfo=pytz.utc), forecast_base_times=["07:00"], dataframe=True))`|![Screenshot of output](/misc/code_example_output4.png?raw=true)|
+
+## Command Line Utilities
+
+### pvforecast
+
+This utility can be used to download data to a CSV file:
+
+```
+usage: pvforecast.py [-h] --user_id <user_id> --api_key <api_key> [-s "<yyyy-mm-dd HH:MM:SS>"] [-e "<yyyy-mm-dd HH:MM:SS>"]
+                     [--entity_type <entity_type>] [--entity_id <entity_id>] [-q] [-o </path/to/output/file>] [-http <http_proxy>]
+                     [-https <https_proxy>]
+
+This is a command line interface (CLI) for the PVForecast API module
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --user_id <user_id>   PVForecast user id.
+  --api_key <api_key>   Path to .txt file holding PVForecast API key.
+  -s "<yyyy-mm-dd HH:MM:SS>", --start "<yyyy-mm-dd HH:MM:SS>"
+                        Specify a UTC start date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the
+                        latest outturn.
+  -e "<yyyy-mm-dd HH:MM:SS>", --end "<yyyy-mm-dd HH:MM:SS>"
+                        Specify a UTC end date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the
+                        latest outturn.
+  --entity_type <entity_type>
+                        Specify an entity type, either 'gsp' or 'pes'. Default is 'gsp'.
+  --entity_id <entity_id>
+                        Specify an entity ID, default is 0 (i.e. national).
+  -q, --quiet           Specify to not print anything to stdout.
+  -o </path/to/output/file>, --outfile </path/to/output/file>
+                        Specify a CSV file to write results to.
+  -http <http_proxy>, -http-proxy <http_proxy>
+                        HTTP Proxy address
+  -https <https_proxy>, -https-proxy <https_proxy>
+                        HTTPS Proxy address
+
+Jamie Taylor & Ethan Jones, 2022-10-12
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Python implementation of the PV_Forecast web API. See [www.solar.sheffield.ac.
 ## About this repository
 
 * This Python library provides a convenient interface for the PV_Forecast web API to facilitate accessing PV_Forecast results in Python code.
-* Developed and tested with Python 3.8, should work with Python 3.5+. Support for Python 2.7+ has been discontinued as of 2021-02-23.
+* Developed and tested with Python 3.8, should work with Python 3.7+. Support for Python 2.7+ has been discontinued as of 2021-02-23.
 
 ## How do I get set up?
 
@@ -67,8 +67,10 @@ pvf = PVForecast(user_id="", api_key="") # Enter your user_id and api_key here!
 This utility can be used to download data to a CSV file:
 
 ```
-usage: pvforecast.py [-h] --user_id <user_id> --api_key <api_key> [-s "<yyyy-mm-dd HH:MM:SS>"] [-e "<yyyy-mm-dd HH:MM:SS>"]
-                     [--entity_type <entity_type>] [--entity_id <entity_id>] [-q] [-o </path/to/output/file>] [-http <http_proxy>]
+usage: pvforecast.py [-h] --user_id <user_id> [--api_key <api_key>]
+                     [-s "<yyyy-mm-dd HH:MM:SS>"] [-e "<yyyy-mm-dd HH:MM:SS>"]
+                     [--entity_type <entity_type>] [--entity_id <entity_id>]
+                     [-q] [-o </path/to/output/file>] [-http <http_proxy>]
                      [-https <https_proxy>]
 
 This is a command line interface (CLI) for the PVForecast API module
@@ -76,15 +78,21 @@ This is a command line interface (CLI) for the PVForecast API module
 optional arguments:
   -h, --help            show this help message and exit
   --user_id <user_id>   PVForecast user id.
-  --api_key <api_key>   Path to .txt file holding PVForecast API key.
+  --api_key <api_key>   Your PVForecast API key. If not path passed, will
+                        check environment variables for `PVForecastAPIKey` and
+                        finally a config file in same directory named
+                        `.pvforecast_credentials`
   -s "<yyyy-mm-dd HH:MM:SS>", --start "<yyyy-mm-dd HH:MM:SS>"
-                        Specify a UTC start date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the
-                        latest outturn.
+                        Specify a UTC start date in 'yyyy-mm-dd HH:MM:SS'
+                        format (inclusive), default behaviour is to retrieve
+                        the latest outturn.
   -e "<yyyy-mm-dd HH:MM:SS>", --end "<yyyy-mm-dd HH:MM:SS>"
-                        Specify a UTC end date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the
+                        Specify a UTC end date in 'yyyy-mm-dd HH:MM:SS' format
+                        (inclusive), default behaviour is to retrieve the
                         latest outturn.
   --entity_type <entity_type>
-                        Specify an entity type, either 'gsp' or 'pes'. Default is 'gsp'.
+                        Specify an entity type, either 'gsp' or 'pes'. Default
+                        is 'gsp'.
   --entity_id <entity_id>
                         Specify an entity ID, default is 0 (i.e. national).
   -q, --quiet           Specify to not print anything to stdout.
@@ -95,7 +103,7 @@ optional arguments:
   -https <https_proxy>, -https-proxy <https_proxy>
                         HTTPS Proxy address
 
-Jamie Taylor & Ethan Jones, 2022-10-12
+Jamie Taylor & Ethan Jones, 2022-12-10
 ```
 
 ## Documentation

--- a/pvforecast_api/pvforecast.py
+++ b/pvforecast_api/pvforecast.py
@@ -45,7 +45,9 @@ class PVForecast:
     `retries` : int
         Optionally specify the number of retries to use should the API respond with anything
         other than status code 200. Exponential back-off applies inbetween retries.
-
+    `proxies` : Dict
+        Optionally specify a Dict of proxies for http and https requests in the format:
+        {"http": "<address>", "https": "<address>"}
     Notes
     -----
     To obtain a User ID and API key, please visit the `PV_Forecast API website <https://api.solar.sheffield.ac.uk/pvforecast/>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytz
 requests
 numpy
 pandas
+argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pytz
 requests
 numpy
 pandas
-argparse

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.4",
+    version="0.5",
 
     description="A Python interface for the PV_Forecast web API from Sheffield Solar.",
     long_description=long_description,


### PR DESCRIPTION
As per #1, #2; **adds support for proxy connections when making http or https requests** using the requests lib as seen here: https://requests.readthedocs.io/en/latest/user/advanced/#proxies. **Also adds a command line interface to the pvforecast module**.

Includes:
- Updated command line interface to include option to add http and https proxies,
- Handling for the above arguments,
- Further implementation to update the requests session to use the passed-in proxies.
- Updated README and version number.

Doesn't include:
- Updated sphinx documentation - review before generating

cc: @JamieTaylor-TUOS 